### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/ui/mod/src/mod.activity.ts
+++ b/ui/mod/src/mod.activity.ts
@@ -100,7 +100,8 @@ function queues(data: any) {
 
 function merge(base: any, extend: any): void {
   for (const key in extend) {
-    if (isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key]);
+    if (!extend.hasOwnProperty(key) || key === '__proto__' || key === 'constructor') continue;
+    if (base.hasOwnProperty(key) && isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key]);
     else base[key] = extend[key];
   }
   return base;


### PR DESCRIPTION
Potential fix for [https://github.com/pwnautopilots/lila/security/code-scanning/1](https://github.com/pwnautopilots/lila/security/code-scanning/1)

To fix the problem, we need to ensure that the `merge` function does not allow prototype pollution. This can be achieved by:
1. Blocking the properties `__proto__` and `constructor` from being merged.
2. Ensuring that only own properties of the destination object are merged recursively.

We will modify the `merge` function to include these checks. Specifically, we will:
- Add a check to skip the properties `__proto__` and `constructor`.
- Ensure that the property being merged is an own property of the destination object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
